### PR TITLE
threatfox-ingestion staging environment kustomize patch

### DIFF
--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -14,3 +14,4 @@ images:
 patches:
   - path: patch.yaml
   - path: minio-patch.yaml
+  - path: threatfox-ingestion-patch.yaml

--- a/k8s/overlays/staging/threatfox-ingestion-patch.yaml
+++ b/k8s/overlays/staging/threatfox-ingestion-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: threatfox-ingestion
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: threatfox-ingestion
+          env:
+            - name: ENVIRONMENT
+              value: staging


### PR DESCRIPTION
## Summary

This PR adds a staging-specific overlay patch for `threatfox-ingestion` so the service correctly reports `ENVIRONMENT=staging` when deployed through the staging overlay.

## What Changed

- Added `k8s/overlays/staging/threatfox-ingestion-patch.yaml`
- Updated `k8s/overlays/staging/kustomization.yaml` to include the new ThreatFox patch
- Set the `ENVIRONMENT` variable for `threatfox-ingestion` to `staging`

## Why

Previously, the ThreatFox deployment inherited the base environment value of `production`, which caused staging logs and service metadata to incorrectly report the environment as production.

This change keeps the staging overlay consistent with the existing `local-dev` ThreatFox patch pattern and ensures logs/metadata accurately reflect the deployed environment.

## Validation

- Rendered the staging overlay with:

```bash
kubectl kustomize k8s/overlays/staging