### PR TITLE
Add combined ingestion integration test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ kubectl port-forward -n local-dev svc/riskstream 8081:80
 # MinIO Console: http://localhost:9001 (login: minioadmin/minioadmin)
 ```
 
+For the in-cluster ingestion integration test workflow, see [riskstream/tests/integration/README.md](riskstream/tests/integration/README.md).
+
 Clean up:
 
 ```bash

--- a/riskstream/services/ingestion/cisa-kev/README.md
+++ b/riskstream/services/ingestion/cisa-kev/README.md
@@ -58,3 +58,9 @@ kubectl logs -n local-dev -l app=cisa-kev-ingestion -f
 pytest riskstream/tests/unit/test_cisa_kev_ingestion.py -q
 ./scripts/run-cisa-kev-integration-test.sh
 ```
+
+To run both ingestion integration tests in sequence from one entrypoint:
+
+```bash
+./scripts/run-ingestion-integration-tests.sh
+```

--- a/riskstream/services/ingestion/threatfox/README.md
+++ b/riskstream/services/ingestion/threatfox/README.md
@@ -112,6 +112,12 @@ For service-level validation inside Kubernetes, run the in-cluster integration t
 ./scripts/run-threatfox-integration-test.sh
 ```
 
+To run both ingestion integration tests in sequence from one entrypoint:
+
+```bash
+./scripts/run-ingestion-integration-tests.sh
+```
+
 ## ThreatFox API
 
 The service uses the [ThreatFox API v1](https://threatfox.abuse.ch/api/) which provides:

--- a/riskstream/tests/integration/README.md
+++ b/riskstream/tests/integration/README.md
@@ -12,6 +12,28 @@ Integration tests ensure that services work correctly together, testing:
 
 ## Running Tests
 
+### Run both ingestion integration tests
+
+Deploy the local-dev environment first:
+
+```bash
+./scripts/build-and-deploy-local.sh
+```
+
+Then run both in-cluster ingestion integration tests sequentially:
+
+```bash
+./scripts/run-ingestion-integration-tests.sh
+```
+
+You can also target a single service through the wrapper by passing its name:
+
+```bash
+./scripts/run-ingestion-integration-tests.sh <service>
+```
+
+Use the per-service scripts below when you want the most direct, targeted failure signal.
+
 ### ThreatFox in-cluster test
 
 Deploy the local-dev environment first:
@@ -89,3 +111,4 @@ Integration tests require:
 1. Keep integration tests focused on service boundaries.
 2. Prefer in-cluster execution for Kubernetes services.
 3. Verify live contracts without mocking when the goal is true integration coverage.
+4. Use the combined wrapper for convenience, and the per-service scripts for targeted troubleshooting.

--- a/scripts/run-ingestion-integration-tests.sh
+++ b/scripts/run-ingestion-integration-tests.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="${1:-all}"
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/run-ingestion-integration-tests.sh [threatfox|cisa-kev|all]
+
+Run in-cluster ingestion integration tests for one service or both services.
+Defaults to "all".
+EOF
+}
+
+run_threatfox() {
+  echo "Running ThreatFox integration test..."
+  "${ROOT_DIR}/scripts/run-threatfox-integration-test.sh"
+}
+
+run_cisa_kev() {
+  echo "Running CISA KEV integration test..."
+  "${ROOT_DIR}/scripts/run-cisa-kev-integration-test.sh"
+}
+
+case "${TARGET}" in
+  threatfox)
+    run_threatfox
+    ;;
+  cisa-kev)
+    run_cisa_kev
+    ;;
+  all)
+    run_threatfox
+    run_cisa_kev
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

Adds a combined ingestion integration test runner and updates the docs around how ingestion integration tests are discovered and run.

  ## Changes

  - Adds `scripts/run-ingestion-integration-tests.sh`
  - Supports running:
      - all ingestion integration tests
      - a single ingestion service integration test
  - Updates `riskstream/tests/integration/README.md` to document the combined runner and keep the integration workflow centralized
  - Updates the root README.md to point readers to the integration test README
  - Updates the ThreatFox and CISA KEV service READMEs to mention the combined runner alongside their service-specific integration commands

  ## Why

  This gives developers and operators a single entrypoint for ingestion integration checks while preserving the existing per-service scripts for targeted troubleshooting.

  ## Verification

  - bash -n scripts/run-ingestion-integration-tests.sh
  - ./scripts/run-ingestion-integration-tests.sh --help

  ## Notes

  - This PR does not change the existing per-service integration test scripts.
  - Full in-cluster integration tests were not run as part of this change.